### PR TITLE
Set default for missing values to NA in multiple ROI data

### DIFF
--- a/R/Flyception2.R
+++ b/R/Flyception2.R
@@ -846,7 +846,7 @@ Flyception2R <- function(dir, outdir=NA, autopos=T, interaction=T, stimulus=F, r
     ratioave <- cbind(ratioave,ratioavei)
     
     # Write intensities and ratio for this ROI
-    redout <- grnout <- ratout <- array(0,length(frid))
+    redout <- grnout <- ratout <- array(NA,length(frid))
     redout[goodfr] <- redavei
     grnout[goodfr] <- grnavei
     ratout[goodfr] <- ratioavei


### PR DESCRIPTION
bugfix: allocate NA for missing values in multiple ROI data instead of 0